### PR TITLE
Избавляемся от неопределённых переменных.

### DIFF
--- a/private/config.php
+++ b/private/config.php
@@ -38,3 +38,6 @@ $conf['youtube_secret'] = 'secret';
 
 $conf['push_all'] = 'secret';
 $conf['push_sanasol'] = 'secret';
+
+$conf['mysql_host'] = 'mariadb';
+$conf['sphinx_host'] = 'sphinx';


### PR DESCRIPTION
Переменные должны быть определены пустыми вне foreach-ей. Это логически верно и избавляет нас от ненужных предупреждений.