### PR TITLE
Обновление ссылки в карточках релизов

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -592,11 +592,22 @@ p.lasttortext {
 	cursor: pointer;
 }
 
+.side-anime-desc > a.release-link {
+	display: block;
+	height: 100%;
+	left: 0;
+	position: absolute;
+	top: 0;
+	width: 100%;
+	z-index: 52;
+}
+
 .last_tor_wrapper {
 	position: absolute;
 	bottom: 10px;
 	width: 100%;
 	left: 0;
+	z-index: 53;
 }
 
 .last_tor_button {
@@ -607,7 +618,6 @@ p.lasttortext {
 	padding: 5px 15px;
 	color: #fff;
 	font-size: 10pt;
-	z-index: 53;
 	border-radius: 4px;
 }
 .last_tor_button:hover {

--- a/private/template/torrent-block.html
+++ b/private/template/torrent-block.html
@@ -1,6 +1,8 @@
 <div class="torrent-block">
 	<div class="torrent_block">
-		<div class="side-anime-desc" onclick="location.href='/release/{id}.html';">
+		<div class="side-anime-desc">
+			<a class="release-link" href="/release/{id}.html"></a>
+
 			<span class="side-runame">{runame}</span>
 			<span class="side-series">Серия: {series}</span>
 			<span class="side-description">{description}</span>


### PR DESCRIPTION
Изменён способ перехода на релиз: вместо `onclick="location.href='/release/{id}.html';"` используется `<a href="/release/{id}.html">`. Это, например, позволяет открывать релиз в новом окне через `Ctrl + Left Click`