### PR TITLE
Кнопка для просмотра серии во внешнем плеере Android

### DIFF
--- a/private/template/playerjs.html
+++ b/private/template/playerjs.html
@@ -26,7 +26,7 @@
 					.file
 					.split(",")
 					.map(it => ({
-						quality: it.match(/\[(\d{1,}p)\]/)[1],
+						quality: it.match(/\[(\d{3,4}p)\]/)[1],
 						link: it.match(/\/\/(.+)$/)[1]
 					}));
 				// get a link with the specified quality

--- a/private/template/playerjs.html
+++ b/private/template/playerjs.html
@@ -1,4 +1,53 @@
 <script src="{playerjs}" type="text/javascript"></script>
 <script>
-	var player = new Playerjs({ id:"anilibriaPlayer", file:[{playlist}], default_quality:"1080p", preroll_deny:"{deny}"});
+	const playlist = [{playlist}];
+	const player = new Playerjs({
+		id: "anilibriaPlayer",
+		file: playlist,
+		default_quality: "1080p",
+		preroll_deny: "{deny}"
+	});
+
+	const shareVideoButton = document.querySelector("button#buttonIntentShare");
+
+	// if the site is open on the android platform add button for view series in an external player
+	if (navigator.userAgent.match(/android/i) && navigator.vendor.match(/Google Inc./i)) {
+		shareVideoButton.setAttribute("disabled", false);
+		// share video button click listener
+		shareVideoButton.onclick = (event) => {
+			try {
+				// get selected video id
+				const selectedSeriesId = player.api("playlist_id");
+				// get current video quality
+				const selectedSeriesVideoQuality = player.api("quality");
+				// get video links by id and map to { "qulity": "quality", "link": "link" }
+				const selectedSeriesVideoLinks = playlist
+					.find(it => it.id === selectedSeriesId)
+					.file
+					.split(",")
+					.map(it => ({
+						quality: it.match(/\[(\d{1,}p)\]/)[1],
+						link: it.match(/\/\/(.+)$/)[1]
+					}));
+				// get a link with the specified quality
+				const selectedVideoLink = selectedSeriesVideoLinks
+					.find(it => it.quality === selectedSeriesVideoQuality)
+					.link;
+
+				// intent meta
+				const schema = location.protocol.substring(0, location.protocol.length - 1);
+				const action = "android.intent.action.VIEW";
+				const mimeType = "video/m3u8"; // video/*, video/mp4, etc
+				// make and call intent
+				window.location = `intent://${selectedVideoLink}#Intent;
+					scheme=${schema};
+					action=${action};
+					type=${mimeType};
+					end`;
+			} catch (err) {
+				console.error(err);
+				alert('OOPS, не работает');
+			}
+		}
+	}
 </script>

--- a/private/template/release.html
+++ b/private/template/release.html
@@ -99,7 +99,7 @@
 		<div class="tab-content">
 			<button id="buttonAni" data-tab="anilibriaPlayer" class="active">Наш плеер</button>
 			<button id="buttonMoon" data-tab="moonPlayer" style="display: none;">Внешний плеер</button>
-			<button id="buttonIntentShare">Плеер Android</button>
+			<button id="buttonIntentShare" disabled>Плеер Android</button>
 			<button data-light class="xdark z-fix">Свет</button>
 			{button}
 			<button data-online-table class="presence_online"></button>

--- a/private/template/release.html
+++ b/private/template/release.html
@@ -99,6 +99,7 @@
 		<div class="tab-content">
 			<button id="buttonAni" data-tab="anilibriaPlayer" class="active">Наш плеер</button>
 			<button id="buttonMoon" data-tab="moonPlayer" style="display: none;">Внешний плеер</button>
+			<button id="buttonIntentShare">Плеер Android</button>
 			<button data-light class="xdark z-fix">Свет</button>
 			{button}
 			<button data-online-table class="presence_online"></button>


### PR DESCRIPTION
Добавил кнопку просмотра серии через внешний плеер Android. Гораздо удобнее смотреть серии через привычный плеер (`MX Player`, `VLC`, etc), чем через плеер браузера.

Протестировано через `Google Chrome` для `MX Player`, `VLC` и стандартный проигрыватель `Lineage OS`.