### PR TITLE
fix(Api): filter playlist field

### DIFF
--- a/private/api.php
+++ b/private/api.php
@@ -454,10 +454,12 @@ function apiList()
             unset($val['playlist']['online']);
 
 
-            // Check if user is cache tester
-            // Fetch fresh list of episodes (not from cache) as cache tester
-            if ($userIsCacheTester === true) {
-                $val['playlist'] = json_decode(getApiPlaylist($val['id'], true), true);
+            if (!in_array('playlist', $unsettedFileds)) {
+                // Check if user is cache tester
+                // Fetch fresh list of episodes (not from cache) as cache tester
+                if ($userIsCacheTester === true) {
+                    $val['playlist'] = json_decode(getApiPlaylist($val['id'], true), true);
+                }
             }
 
             $result[] = $val;


### PR DESCRIPTION
Сейчас playlist возвращается всегда, не смотря на то, что указано в фильтрах. Исправил это.

Тут бы конечно еще $userIsCacheTester не вычислять лишний раз, но это надо будет сильно менять фильтрацию полей. 