### PR TITLE
Хотфикс для рокет лоадера который мешает выполнению скрипта темной темы

### DIFF
--- a/private/header.php
+++ b/private/header.php
@@ -77,7 +77,7 @@ $xcss = headerAds();
 <!DOCTYPE html>
 <html prefix="og: http://ogp.me/ns#">
 	<head>
-		<script src="<?php echo '/js/theme-toggle.js';?>"></script>
+		<script data-cfasync="false" src="<?php echo '/js/theme-toggle.js';?>"></script>
 
         <!-- Global site tag (gtag.js) - Google Analytics -->
 		<script async src="https://www.googletagmanager.com/gtag/js?id=<?php global $conf; echo $conf['google_analytics_id']; ?>"></script>


### PR DESCRIPTION
Из за присутствия рокет лоадера скрипт темный темы не может нормально отработать и мелькает белая тема.
Связано это с тем что рокет лоадер комментирует все скрипты до полной загрузки всех скриптов.
Чтобы рокет лоадер игнорировал скрипт смены темы и не мешал ему отработать и сделан этот пул реквест.
https://developers.cloudflare.com/fundamentals/speed/rocket-loader/ignore-javascripts/
![image](https://user-images.githubusercontent.com/5034345/226064488-61ef21f0-14b1-4807-af18-b5038595de0d.png)
